### PR TITLE
Add GitHub Actions workflow for npm package publishing

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -1,0 +1,36 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for publishing Node.js packages to GitHub Packages when a release is created. The workflow ensures that tests are run before publishing and handles authentication securely.

Continuous Integration and Publishing:

* Added `.github/workflows/npm-publish-github-packages.yml` to automate testing and publishing of Node.js packages to GitHub Packages upon release creation.
* Configured the workflow to run tests with `npm test` after installing dependencies and to publish only when tests pass.
* Set up secure authentication for publishing by using the `GITHUB_TOKEN` secret.This workflow runs tests and publishes a Node.js package to GitHub Packages upon release creation.